### PR TITLE
Ajout d'une gemspec

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link crossorigin="anonymous" rel="stylesheet" href="{{ '/assets/style/bootstrap.min.css' | relative_url }}">
-    <link href="https://josephk.frama.io/accueil/main.css" rel="stylesheet" type="text/css" />
+    <link href="https://framasoft.org/main.502ace832b1505e92826.css" rel="stylesheet" type="text/css" />
     <link crossorigin="anonymous" rel="stylesheet" href="{{ '/assets/style/framalibre-notice.css' | relative_url }}">
     <link crossorigin="anonymous" rel="stylesheet" href="{{ '/assets/style/surcharge.css' | relative_url }}">
 

--- a/kabusin.gemspec
+++ b/kabusin.gemspec
@@ -1,0 +1,32 @@
+Gem::Specification.new do |spec|
+  spec.name        = "kabusin"
+  spec.version     = "1.0.0"
+  spec.authors     = ["Scribouilli"]
+  spec.email       = "coucou@scribouilli.org"
+
+  spec.summary     = "Kabusin, a Jekyll theme"
+  spec.homepage    = "https://git.scribouilli.org/scribouilli/kabusin"
+  spec.description = "Kabusin is a Jekyll theme for Framalibre mini-sites, built with Scribouilli."
+  spec.license     = "MIT"
+
+  spec.metadata["plugin_type"] = "theme"
+  spec.required_ruby_version = ">= 3.2.0"
+
+  spec.files = `git ls-files -z`.split("\x0").select do |f|
+    f.match(%r!^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))!i)
+  end
+
+  spec.add_runtime_dependency "jekyll", "~> 4.3.2"
+  spec.add_runtime_dependency "jekyll-redirect-from", "~> 0.16"
+  spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
+  spec.add_runtime_dependency "jekyll-feed", "~> 0.17"
+  spec.add_runtime_dependency "jekyll-paginate-v2", "~> 3.0"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.8"
+  spec.add_runtime_dependency "jekyll-optional-front-matter", "~> 0.3"
+  spec.add_runtime_dependency "jekyll-default-layout", "~> 0.1.5"
+  spec.add_runtime_dependency "jekyll-titles-from-headings", "~> 0.5.3"
+
+
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 12.0"
+end


### PR DESCRIPTION
## Description 

Afin de pouvoir installer ce thème via les GitHub Actions et GitLab CI, on a besoin que ce thème soit structuré comme une gem Ruby. Cette PR ajoute donc un fichier `kabusin.gemspec` pour cela.

J'ai repris les mêmes options que sur le [gemspec de Mimoza](https://github.com/Scribouilli/mimoza/blob/main/mimoza.gemspec).